### PR TITLE
apidoc: handle entity inheritance chains, expose ALL entities, type||using fallback, realistic mock names

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ end
 
 ## Examples
 
-- API: [spec/scenario/mock_project.rb](spec/scenario/mock_project.rb)
-- Resulting doc: [spec/fixtures/mock_project.md](spec/fixtures/mock_project.md)
+- API: [spec/scenario/example.rb](spec/scenario/example.rb)
+- Resulting doc: [spec/fixtures/example.md](spec/fixtures/example.md)

--- a/lib/grape/apidoc.rb
+++ b/lib/grape/apidoc.rb
@@ -56,7 +56,6 @@ module Grape
       @out.puts '# Entities'
       @out.puts
 
-      # TODO: maybe we'll have to dig into entity exposures
       entities.each do |entity|
         write_entity_header!(entity)
         @out.puts

--- a/lib/grape/apidoc.rb
+++ b/lib/grape/apidoc.rb
@@ -27,11 +27,37 @@ module Grape
       end
     end
 
+    # Returns all the entities used in app.
+    def entities
+      @entities ||= begin
+        acc = {}
+        @api.routes.filter_map(&:entity).each do |entity|
+          collect_entities(acc, entity)
+        end
+        acc.keys.sort_by(&:name)
+      end
+    end
+
+    # Recursively collects entities.
+    # @param acc Hash entity_class => true lookup/accumulator
+    # @param entity Grape::Entity root/seed entity
+    def collect_entities(acc, entity)
+      return if acc[entity]
+
+      acc[entity] = true
+
+      entity.root_exposures.each do |exp|
+        via = exp.try(:using_class_name)
+        collect_entities(acc, via) if via
+      end
+    end
+
     def write_entities!
       @out.puts '# Entities'
       @out.puts
 
-      @api.routes.filter_map(&:entity).uniq.sort_by(&:name).each do |entity|
+      # TODO: maybe we'll have to dig into entity exposures
+      entities.each do |entity|
         write_entity_header!(entity)
         @out.puts
 
@@ -45,7 +71,7 @@ module Grape
     end
 
     def write_entity_fields!(entity)
-      unless entity.documentation.present?
+      unless entity.root_exposures.present?
         @out.puts '*No fields exposed.*'
         return
       end
@@ -53,11 +79,19 @@ module Grape
       @out.puts FIELDS_TABLE.format('Field', 'Type', 'Description')
       @out.puts FIELDS_TABLE.separator
 
-      entity.documentation.each do |name, details|
-        # Problem: it's pretty much impossible to match Entity to model to dig column types.
-        # Need to either enforce some requirements for organizing API or give up.
-        type, desc, = details.values_at(:type, :desc)
-        type = "[#{type}]" if details[:is_array]
+      entity.root_exposures.each do |exposure|
+        name = exposure.attribute
+        doc = entity.documentation[name] || {}
+        type, desc, = doc.values_at(:type, :desc)
+
+        # fall back to `using:...`
+        unless type
+          via = exposure.try(:using_class_name)
+          via_name = entity_name(via) if via
+          type = "[#{via_name}](##{identifier(via_name)})"
+        end
+
+        type = "[#{type}]" if doc[:is_array]
         @out.puts FIELDS_TABLE.format(name.to_s, type.to_s, desc.to_s)
       end
     end
@@ -121,16 +155,16 @@ module Grape
       @out.puts FIELDS_TABLE.format('Parameter', 'Type', 'Description')
       @out.puts FIELDS_TABLE.separator
 
-      route.params.each do |name, details|
+      route.params.each do |name, doc|
         # route.params includes path params as well, like `id => ''`
         # (not a hash, like normal params):
-        details = {} unless details.is_a?(Hash)
+        doc = {} unless doc.is_a?(Hash)
 
         # Problem: it's pretty much impossible to match Entity to model to dig column types.
         # Problem: it's not guaranteed that Entity exposures match params.
         # Need to either enforce some requirements for organizing API or give up.
-        type = details[:type] || ''
-        desc = details.except(:type).map {|k, v| "#{k}: #{v}" }.join(', ')
+        type = doc[:type] || ''
+        desc = doc.except(:type).map {|k, v| "#{k}: #{v}" }.join(', ')
         @out.puts FIELDS_TABLE.format(name.to_s, type, desc)
       end
     end

--- a/lib/grape/apidoc.rb
+++ b/lib/grape/apidoc.rb
@@ -86,8 +86,10 @@ module Grape
         # fall back to `using:...`
         unless type
           via = exposure.try(:using_class_name)
-          via_name = entity_name(via) if via
-          type = "[#{via_name}](##{identifier(via_name)})"
+          if via
+            via_name = entity_name(via)
+            type = "[#{via_name}](##{identifier(via_name)})"
+          end
         end
 
         type = "[#{type}]" if doc[:is_array]

--- a/spec/fixtures/example.md
+++ b/spec/fixtures/example.md
@@ -1,23 +1,23 @@
 # Entities
 
-## Mock:Role
+## Example:Role
 
 | Field                | Type       | Description                              |
 | -------------------- | ---------- | ---------------------------------------- |
 | name                 | String     | Role Name                                |
 
-## Mock:User
+## Example:User
 
 | Field                | Type       | Description                              |
 | -------------------- | ---------- | ---------------------------------------- |
 | email                | String     | User Email                               |
 
-## Mock:User:Full
+## Example:User:Full
 
 | Field                | Type       | Description                              |
 | -------------------- | ---------- | ---------------------------------------- |
 | email                | String     | User Email                               |
-| roles                | [[Mock:Role](#mock-role)] | User Roles                               |
+| roles                | [[Example:Role](#example-role)] | User Roles                               |
 
 # Routes
 
@@ -25,7 +25,7 @@
 
 List Users
 
-- **Returns**: List of [Mock:User](#mock-user)
+- **Returns**: List of [Example:User](#example-user)
 - **Security**: `required=["admin/users.read"]`
 
 **Parameters**:
@@ -39,7 +39,7 @@ List Users
 
 Update User
 
-- **Returns**: [Mock:User:Full](#mock-user-full)
+- **Returns**: [Example:User:Full](#example-user-full)
 
 **Parameters**:
 

--- a/spec/fixtures/mock_project.md
+++ b/spec/fixtures/mock_project.md
@@ -1,45 +1,51 @@
 # Entities
 
-## Mock:Bar
+## Mock:Role
 
 | Field                | Type       | Description                              |
 | -------------------- | ---------- | ---------------------------------------- |
-| bar_id               | Integer    | Bar ID                                   |
-| foos                 | [Object]   | Associated Foos                          |
+| name                 | String     | Role Name                                |
 
-## Mock:Foo
+## Mock:User
 
 | Field                | Type       | Description                              |
 | -------------------- | ---------- | ---------------------------------------- |
-| foo_id               | Integer    | Foo ID                                   |
+| email                | String     | User Email                               |
+
+## Mock:User:Full
+
+| Field                | Type       | Description                              |
+| -------------------- | ---------- | ---------------------------------------- |
+| email                | String     | User Email                               |
+| roles                | [[Mock:Role](#mock-role)] | User Roles                               |
 
 # Routes
 
-## GET /api/v1/foos
+## GET /api/v1/users
 
-List Foos
+List Users
 
-- **Returns**: List of [Mock:Foo](#mock-foo)
-- **Security**: `required=["foo/bar.baz", "foo/bar.qux"]`
-
-**Parameters**:
-
-| Parameter            | Type       | Description                              |
-| -------------------- | ---------- | ---------------------------------------- |
-| filter               | Array      | required: false                          |
-| filter[foo_id]       | [Integer]  | required: false                          |
-
-## POST /api/v1/bars/:id
-
-Create Bar
-
-- **Returns**: [Mock:Bar](#mock-bar)
+- **Returns**: List of [Mock:User](#mock-user)
+- **Security**: `required=["admin/users.read"]`
 
 **Parameters**:
 
 | Parameter            | Type       | Description                              |
 | -------------------- | ---------- | ---------------------------------------- |
-| foos                 | [JSON]     | required: false                          |
-| foos[foo_id]         | Integer    | required: false                          |
-| id                   |            |                                          |
+| filter               | Hash       | required: false                          |
+| filter[email]        | [String]   | required: false                          |
+
+## PUT /api/v1/users/:email
+
+Update User
+
+- **Returns**: [Mock:User:Full](#mock-user-full)
+
+**Parameters**:
+
+| Parameter            | Type       | Description                              |
+| -------------------- | ---------- | ---------------------------------------- |
+| roles                | [JSON]     | required: false                          |
+| roles[name]          | String     | required: true                           |
+| email                |            |                                          |
 

--- a/spec/grape/apidoc_spec.rb
+++ b/spec/grape/apidoc_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Grape::Apidoc do
   subject(:apidoc) do
-    described_class.new(Mock::API, output: doc) # see spec/scenario for Mock::* impl
+    described_class.new(Example::API, output: doc) # see spec/scenario for Example::* impl
   end
 
   let(:doc) { StringIO.new }
@@ -12,7 +12,7 @@ RSpec.describe Grape::Apidoc do
   end
 
   it 'documents api' do
-    # File.write('spec/fixtures/mock_project.md', doc.string)
-    expect(doc.string.strip).to eq(File.read('spec/fixtures/mock_project.md').strip)
+    # File.write('spec/fixtures/example.md', doc.string)
+    expect(doc.string.strip).to eq(File.read('spec/fixtures/example.md').strip)
   end
 end

--- a/spec/scenario/example.rb
+++ b/spec/scenario/example.rb
@@ -1,4 +1,4 @@
-module Mock
+module Example
   Role = Struct.new(:name)
   User = Struct.new(:email, :roles)
 

--- a/spec/scenario/mock_project.rb
+++ b/spec/scenario/mock_project.rb
@@ -1,47 +1,51 @@
 module Mock
-  Foo = Struct.new(:foo_id) # model
+  Role = Struct.new(:name)
+  User = Struct.new(:email, :roles)
 
-  class Foo::Entity < Grape::Entity
-    expose :foo_id, documentation: { type: 'Integer', desc: 'Foo ID' }
+  class Role::Entity < Grape::Entity
+    expose :name, documentation: { type: 'String', desc: 'Role Name' }
   end
 
-  Bar = Struct.new(:bar_id, :foos) # model
+  class User::Entity < Grape::Entity
+    expose :email, documentation: { type: 'String', desc: 'User Email' }
+  end
 
-  class Bar::Entity < Grape::Entity
-    expose :bar_id, documentation: { type: 'Integer', desc: 'Bar ID' }
-    expose :foos,
-           using: Mock::Foo::Entity,
-           documentation: { type: 'Object', is_array: true, desc: 'Associated Foos' }
+  class User::FullEntity < User::Entity
+    expose :roles,
+           using: Role::Entity,
+           documentation: { is_array: true, desc: 'User Roles' } # if `type:...` omited it'll be inferred from `using:...`
   end
 
   class API < Grape::API
     prefix 'api'
     version 'v1'
 
-    desc 'List Foos' do
-      success Mock::Foo::Entity
+    desc 'List Users' do
+      success User::Entity
       is_array true
-      security required: %w[foo/bar.baz foo/bar.qux]
+      security required: %w[admin/users.read]
     end
     params do
-      optional :filter, type: Array do
-        optional :foo_id, type: [Integer]
+      optional :filter, type: Hash do
+        optional :email, type: [String]
       end
     end
-    get('/foos') { [Mock::Foo.new(foo_id: 1)] }
+    get '/users' do
+      [User.new(email: 'test@test.com')]
+    end
 
-    desc 'Create Bar' do
-      success Mock::Bar::Entity
+    desc 'Update User' do
+      success User::FullEntity
     end
     params do
-      optional :foos, type: Array[JSON] do
-        optional :foo_id, type: Integer
+      optional :roles, type: Array[JSON] do
+        requires :name, type: String
       end
     end
-    post('/bars/:id') do
-      Mock::Bar.new(
-        bar_id: 2,
-        foos: [Mock::Foo.new(foo_id: 1)],
+    put '/users/:email', requirements: { email: %r{\A[^/]+\Z} } do
+      User.new(
+        email: 'test@test.com',
+        roles: [Role.new(name: 'admin')],
       )
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,4 +4,4 @@ require 'grape'
 require 'grape-entity'
 require 'stringio'
 
-require_relative './scenario/mock_project'
+require_relative './scenario/example'


### PR DESCRIPTION
Now exposures for entity inheritance chains (like `ExtendedEntity < RootEntity`) are handled correctly.
Previously, only top-level (used in route doc) entities were documented, now all the referenced entities are documented (collected recursively from `using:...`).
Also, added fallback to detect type from `using:...` if `documentation[:type]` not specified (with a nice link to entity).
And changed mock names to be more real-world ones (Foo/Bar -> User/Role).